### PR TITLE
fix: use  --inline on 4.1.0 or greater

### DIFF
--- a/src/capacitor-sync.ts
+++ b/src/capacitor-sync.ts
@@ -30,7 +30,7 @@ export function capacitorSync(project: Project): string {
 }
 
 function capCLISync(): string {
-  if (isGreaterOrEqual('@capacitor/cli', '4.0.0')) {
+  if (isGreaterOrEqual('@capacitor/cli', '4.1.0')) {
     return `npx cap sync --inline`;
   }
   return `npx cap sync`;


### PR DESCRIPTION
--inline was introduced in 4.1.0, not in 4.0.0