### PR TITLE
1.90

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### Version 1.90.0
+
+- The ionic:build or build command in package.json will now override the default build command
+
 ### Version 1.89.0
 
 - Replace Ionic start with npm create ionic

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ionic",
-  "version": "1.89.0",
+  "version": "1.90.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ionic",
-      "version": "1.89.0",
+      "version": "1.90.0",
       "license": "MIT",
       "dependencies": {
         "-": "^0.0.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ionic",
   "displayName": "Ionic",
   "description": "Official extension for Ionic and Capacitor development",
-  "version": "1.89.0",
+  "version": "1.90.0",
   "icon": "media/ionic.png",
   "publisher": "Ionic",
   "keywords": [

--- a/src/ionic-build.ts
+++ b/src/ionic-build.ts
@@ -85,10 +85,10 @@ function buildCmd(project: Project): string {
   switch (project.frameworkType) {
     case 'angular':
     case 'angular-standalone':
-      return 'ng build';
+      return guessBuildCommand(project) ?? 'ng build';
     case 'vue-vite':
     case 'react-vite':
-      return `vite build`;
+      return guessBuildCommand(project) ?? 'vite build';
     case 'react':
       return 'react-scripts build';
     case 'vue':


### PR DESCRIPTION
The ionic:build or build command in package.json will now override the default build command