### PR TITLE
v1.95

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### Version 1.95
 
 - Support for NextJS projects using static exports with an `out` folder
+- Support for Non-Ionic projects using `serve`, `build` and `start` scripts
+- Support for Capacitor Plugin monorepos
 
 ### Version 1.94
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### Version 1.95
+
+- Support for NextJS projects using static exports with an `out` folder
+
 ### Version 1.94
 
 - Options for running in the web browser, VS Code editor, Nexus browser added as icons

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ionic",
   "displayName": "Ionic",
   "description": "Official extension for Ionic and Capacitor development",
-  "version": "1.94.2",
+  "version": "1.95.0",
   "icon": "media/ionic.png",
   "publisher": "Ionic",
   "keywords": [

--- a/src/capacitor-config-file.ts
+++ b/src/capacitor-config-file.ts
@@ -42,6 +42,8 @@ export function getCapacitorConfigDistFolder(folder: string): string {
       result = 'dist';
     } else if (existsSync(join(folder, 'build'))) {
       result = 'build';
+    } else if (existsSync(join(folder, 'out'))) {
+      result = 'out';
     }
   }
   if (!result) {

--- a/src/ionic-build.ts
+++ b/src/ionic-build.ts
@@ -110,6 +110,8 @@ function guessBuildCommand(project: Project): string | undefined {
     const packageFile = JSON.parse(readFileSync(filename, 'utf8'));
     if (packageFile.scripts['ionic:build']) {
       return npmRun('ionic:build');
+    } else if (packageFile.scripts['build']) {
+      return npmRun('build');
     }
   }
   return undefined;

--- a/src/ionic-serve.ts
+++ b/src/ionic-serve.ts
@@ -124,13 +124,15 @@ function guessServeCommand(project: Project): string | undefined {
     const packageFile = JSON.parse(readFileSync(filename, 'utf8'));
     if (packageFile.scripts['ionic:serve']) {
       return npmRun('ionic:serve');
-    }
-    if (packageFile.scripts?.serve) {
+    } else if (packageFile.scripts?.serve) {
       return npmRun('serve');
+    } else if (packageFile.scripts?.start) {
+      return npmRun('start');
     }
   }
   return undefined;
 }
+
 async function findNextPort(port: number, host: string | undefined): Promise<number> {
   let availablePort = port;
   while (await isPortInUse(availablePort, host)) {

--- a/src/monorepo.ts
+++ b/src/monorepo.ts
@@ -393,7 +393,11 @@ function checkFolder(filename: string): FolderType {
       pck?.dependencies?.['@capacitor/android'] ||
       pck?.dependencies?.['@angular/core']
     );
-    return isIonic ? FolderType.hasIonic : pck.dependencies ? FolderType.hasDependencies : FolderType.unknown;
+    return isIonic
+      ? FolderType.hasIonic
+      : pck.dependencies || pck.devDependencies
+        ? FolderType.hasDependencies
+        : FolderType.unknown;
   } catch {
     return FolderType.unknown;
   }


### PR DESCRIPTION
- Support for NextJS projects using static exports with an `out` folder
- Support for Non-Ionic projects using `serve`, `build` and `start` scripts
- Support for Capacitor Plugin mono repos