### PR TITLE
fix: parameter passing, folder based mono repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Changelog
 
+### Version 1.96
+
+- For build command use `--` to ensure parameters are passed
+- Support for folder based monorepos with Non-Ionic projects
+
 ### Version 1.95
 
 - Support for NextJS projects using static exports with an `out` folder

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ionic",
   "displayName": "Ionic",
   "description": "Official extension for Ionic and Capacitor development",
-  "version": "1.95.0",
+  "version": "1.96.0",
   "icon": "media/ionic.png",
   "publisher": "Ionic",
   "keywords": [

--- a/src/ionic-build.ts
+++ b/src/ionic-build.ts
@@ -65,6 +65,12 @@ function build(
 ): string {
   let cmd = `${npx(project)} ${buildCmd(project)}`;
   if (configurationArg) {
+    if (cmd.includes('npm run ')) {
+      // This adds -- if the command is npm run build but does not if it is something like ng build
+      cmd += ' -- --';
+    } else if (cmd.includes('run ')) {
+      cmd += ' --';
+    }
     cmd += ` ${configurationArg}`;
   } else if (prod) {
     cmd += ' --prod';

--- a/src/monorepo.ts
+++ b/src/monorepo.ts
@@ -239,12 +239,10 @@ function getFolderBasedProjects(prj: Project): Array<MonoRepoProject> {
       likelyFolderBasedMonoRepo = true;
     }
   }
-  if (!likelyFolderBasedMonoRepo) {
-    return [];
-  }
+
   const rootFolderType = checkFolder(join(prj.folder, 'package.json'));
   if (rootFolderType == FolderType.hasIonic) {
-    if (prj.folder == projects[0].path) {
+    if (projects.length == 0 || prj.folder == projects[0].path) {
       // Sub folder is the root folder (eg ionic multi-app without a root)
     } else {
       // Its definitely an Ionic or Capacitor project in the root but we have sub folders that look like Ionic projects so throw error


### PR DESCRIPTION
- For build command use `--` to ensure parameters are passed
- Support for folder based monorepos with Non-Ionic projects