### PR TITLE
feat: fix auto imports for Angular 19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### Version 1.103
+
+- Fix for Angular 19 auto imports and standalone defaulting to true
+
 ### Version 1.102
 
 - Remove the `--external` flag for Capacitor 7

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ionic",
   "displayName": "Ionic",
   "description": "Official extension for Ionic and Capacitor development",
-  "version": "1.102.0",
+  "version": "1.103.0",
   "icon": "media/ionic.png",
   "publisher": "Ionic",
   "keywords": [

--- a/src/imports-angular.ts
+++ b/src/imports-angular.ts
@@ -3,6 +3,7 @@ import { Range, TextDocument, Uri, WorkspaceEdit, workspace } from 'vscode';
 import { toPascalCase } from './utilities';
 import { IonicComponents } from './imports-auto-fix';
 import { Project } from 'ts-morph';
+import { isGreaterOrEqual } from './analyzer';
 
 export async function autoFixAngularImports(document: TextDocument, component: string): Promise<boolean> {
   // Validate that the file changed was a .html file that also has a .ts file which uses @ionic standalone
@@ -18,10 +19,18 @@ export async function autoFixAngularImports(document: TextDocument, component: s
     // Not a known Ionic Component
     return false;
   }
-  if (!tsText.includes('standalone: true')) {
-    // Doesnt include a standalone component
-    console.log(`${tsFile} does not include a standalone component`);
-    return false;
+  const a19 = isGreaterOrEqual('@angular/core', '19.0.0');
+  if (!a19) {
+    if (!tsText.includes('standalone: true')) {
+      // Doesnt include a standalone component
+      console.log(`${tsFile} does not include a standalone component`);
+      return false;
+    }
+  } else {
+    if (tsText.includes('standalone: false')) {
+      // Opted out of standalone components
+      return false;
+    }
   }
   if (tsText.includes('IonicModule')) {
     // Its got the IonicModule kitchen sink


### PR DESCRIPTION
Fixes #230 - Before Angular 19 auto importing Ionic components would work if `standalone` was `true`. After Angular 19 the default is true and the property omitted, so this change fixes this and doesn't require standalone to be specified if Angular is v19+