### PR TITLE
feat: @capacitor/core in `peerDependencies` now also activates the ionic-tree view

### DIFF
--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -137,16 +137,18 @@ export async function load(fn: string, project: Project, context: ExtensionConte
   }
   allDependencies = {
     ...packageFile.dependencies,
+    ...packageFile.peerDependencies,
     ...packageFile.devDependencies,
   };
 
   // Its a capacitor project only if its a dependency and not a dev dependency
-  project.isCapacitor = !!(
-    packageFile.dependencies &&
-    (packageFile.dependencies['@capacitor/core'] ||
-      packageFile.dependencies['@capacitor/ios'] ||
-      packageFile.dependencies['@capacitor/android'])
-  );
+  project.isCapacitor =
+    !!(
+      packageFile.dependencies &&
+      (packageFile.dependencies['@capacitor/core'] ||
+        packageFile.dependencies['@capacitor/ios'] ||
+        packageFile.dependencies['@capacitor/android'])
+    ) || !!(packageFile.peerDependencies && packageFile.peerDependencies['@capacitor/core']);
 
   project.isCordova = !!(allDependencies['cordova-ios'] || allDependencies['cordova-android'] || packageFile.cordova);
 


### PR DESCRIPTION
In previous versions, with `@capacitor/core` set only as a `peerDependency`, the project was not being identified as a Capacitor project.

Now, that is the case.

Reminder : a Capacitor project is detected if `dependencies` imports `@capacitor/core`, `@capacitor/ios` or `@capacitor/android`, or if `peerDependencies` imports `@capacitor/core`.

Fixes #231 