### PR TITLE
feat: deprecation notice for the extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### Version 1.105
+
+- Deprecation in favor of the WebNative extension (https://webnative.dev)
+
 ### Version 1.104
 
 - Fix to remove no-build argument when building with Capacitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ionic",
-  "version": "1.102.0",
+  "version": "1.105.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ionic",
-      "version": "1.102.0",
+      "version": "1.105.0",
       "license": "MIT",
       "dependencies": {
         "@trapezedev/configure": "7.1.3",
@@ -26,7 +26,7 @@
         "@types/glob": "7.2.0",
         "@types/netmask": "^2.0.5",
         "@types/node": "18.19.26",
-        "@types/vscode": "1.65.0",
+        "@types/vscode": "1.98.0",
         "@typescript-eslint/eslint-plugin": "5.12.1",
         "@typescript-eslint/parser": "5.12.1",
         "esbuild": "0.14.23",
@@ -941,9 +941,9 @@
       "license": "MIT"
     },
     "node_modules/@types/vscode": {
-      "version": "1.65.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.65.0.tgz",
-      "integrity": "sha512-wQhExnh2nEzpjDMSKhUvnNmz3ucpd3E+R7wJkOhBNK3No6fG3VUdmVmMOKD0A8NDZDDDiQcLNxe3oGmX5SjJ5w==",
+      "version": "1.98.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.98.0.tgz",
+      "integrity": "sha512-+KuiWhpbKBaG2egF+51KjbGWatTH5BbmWQjSLMDCssb4xF8FJnW4nGH4nuAdOOfMbpD0QlHtI+C3tPq+DoKElg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ionic",
   "displayName": "Ionic",
   "description": "Official extension for Ionic and Capacitor development",
-  "version": "1.104.0",
+  "version": "1.105.0",
   "icon": "media/ionic.png",
   "publisher": "Ionic",
   "keywords": [

--- a/src/recommend.ts
+++ b/src/recommend.ts
@@ -40,12 +40,13 @@ import { cancelLastOperation } from './tasks';
 import { CommandName } from './command-name';
 import { CommandTitle } from './command-title';
 import { ExtensionContext, Uri, commands, env } from 'vscode';
+import { checkRecommendedExtensions } from './vscode-recommendation';
 
 export async function getRecommendations(project: Project, context: ExtensionContext, packages: any): Promise<void> {
   tStart('getRecommendations');
   if (project.isCapacitor) {
     project.setGroup(`Run`, `Press ${alt('R')} to run the last chosen platform or Web.`, TipType.Ionic, true);
-
+    checkRecommendedExtensions(project.folder);
     const hasCapIos = project.hasCapacitorProject(CapacitorPlatform.ios);
     const hasCapAndroid = project.hasCapacitorProject(CapacitorPlatform.android);
 

--- a/src/vscode-recommendation.ts
+++ b/src/vscode-recommendation.ts
@@ -1,0 +1,27 @@
+import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { commands, window } from 'vscode';
+
+export async function checkRecommendedExtensions(folder: string): Promise<void> {
+  const recFile = join(folder, '.vscode', 'extensions.json');
+  if (existsSync(recFile)) {
+    const data = readFileSync(recFile, 'utf8');
+    const jsonData = JSON.parse(data);
+    if (!data.includes('ionic.ionic')) {
+      return;
+    }
+    jsonData.recommendations = jsonData.recommendations.filter((ext: string) => ext !== 'ionic.ionic');
+    if (!data.includes('Webnative.webnative')) {
+      jsonData.recommendations.push('Webnative.webnative');
+    }
+    writeFileSync(recFile, JSON.stringify(jsonData, null, 2), 'utf8');
+    const res = await window.showInformationMessage(
+      'The Ionic extension has been deprecated in favor of the Webnative extension. Install the extension?',
+      'Get Extension',
+      'OK',
+    );
+    if (res === 'Get Extension') {
+      await commands.executeCommand('workbench.extensions.installExtension', 'webnative.webnative');
+    }
+  }
+}


### PR DESCRIPTION
This last change on the VS Code extension replaces the recommended extension for Ionic projects with the [WebNative](https://webnative.dev) extension and displays a deprecation notice and option to install the new extension.